### PR TITLE
Display errors in toast

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -14,8 +14,10 @@ import Login from './components/Login'
 import QRReaderDialog from './components/QRReaderDialog'
 import SecretFormDialog from './components/SecretFormDialog'
 import SecretsTable from './components/SecretsTable'
+import Toast from './components/Toast'
 
 import { ConfirmProvider } from './context/confirm'
+import { ToastProvider } from './context/toast'
 
 function Main({ classes }) {
   const [user, setUser] = useState({})
@@ -70,35 +72,38 @@ function Main({ classes }) {
   return (
     <div className={classes.root}>
       <ConfirmProvider>
-        <AppBar
-          user={user}
-          secrets={secrets}
-          signOut={() => firebase.auth().signOut()}
-        />
-        <Confirm />
-        <QRReaderDialog
-          open={cameraDialog}
-          onClose={() => toggleCameraDialog(false)}
-          addSecret={addSecret}
-        />
-        <SecretFormDialog
-          open={formDialog}
-          onClose={() => toggleFormDialog(false)}
-          addSecret={addSecret}
-          displayName={user.displayName}
-        />
-        <SecretsTable
-          secrets={secrets}
-          updateSecret={updateSecret}
-          removeSecret={removeSecret}
-          idToken={idToken}
-        />
-        <AddSecretButton
-          scanQR={() => toggleCameraDialog(true)}
-          // TODO recover from scan/upload errors
-          uploadImage={file => scan(file).then(addSecret)}
-          manuallyAdd={() => toggleFormDialog(true)}
-        />
+        <ToastProvider>
+          <AppBar
+            user={user}
+            secrets={secrets}
+            signOut={() => firebase.auth().signOut()}
+          />
+          <Confirm />
+          <QRReaderDialog
+            open={cameraDialog}
+            onClose={() => toggleCameraDialog(false)}
+            addSecret={addSecret}
+          />
+          <SecretFormDialog
+            open={formDialog}
+            onClose={() => toggleFormDialog(false)}
+            addSecret={addSecret}
+            displayName={user.displayName}
+          />
+          <SecretsTable
+            secrets={secrets}
+            updateSecret={updateSecret}
+            removeSecret={removeSecret}
+            idToken={idToken}
+          />
+          <Toast />
+          <AddSecretButton
+            scanQR={() => toggleCameraDialog(true)}
+            // TODO recover from scan/upload errors
+            uploadImage={file => scan(file).then(addSecret)}
+            manuallyAdd={() => toggleFormDialog(true)}
+          />
+        </ToastProvider>
       </ConfirmProvider>
     </div>
   )

--- a/src/components/QRReaderDialog.js
+++ b/src/components/QRReaderDialog.js
@@ -1,15 +1,21 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Drawer, Typography, withStyles } from '@material-ui/core'
 import QrReader from 'react-qr-reader'
 import { parse } from '../lib/qr-parser'
+import { showToast, ToastDispatchContext } from '../context/toast'
 
 // intermediate component to leverage laziness evaluation
 // https://material-ui.com/utils/modal/#performance
 function Form({ classes, addSecret, onClose }) {
+  const toastDispatch = useContext(ToastDispatchContext)
+
   const scan = async result => {
     if (result) {
-      // TODO recover from parse errors
-      await addSecret(await parse(result))
+      try {
+        await addSecret(await parse(result))
+      } catch (err) {
+        toastDispatch(showToast(err.message, toastDispatch))
+      }
       onClose()
     }
   }

--- a/src/components/SecretsTable.js
+++ b/src/components/SecretsTable.js
@@ -6,6 +6,7 @@ import {
   ConfirmDispatchContext,
   ConfirmStateContext
 } from '../context/confirm'
+import { showToast, ToastDispatchContext } from '../context/toast'
 
 const colorNames = Object.keys(colors).sort()
 
@@ -18,6 +19,8 @@ function SecretsTable({
 }) {
   const confirmDispatch = useContext(ConfirmDispatchContext)
   const confirmState = useContext(ConfirmStateContext)
+
+  const toastDispatch = useContext(ToastDispatchContext)
 
   const generateToken = async secret => {
     try {
@@ -42,7 +45,7 @@ function SecretsTable({
       await updateSecret(secret._id, { token })
     } catch (e) {
       if (!e.warning) {
-        console.error(e)
+        toastDispatch(showToast(e.message, toastDispatch))
       }
     }
   }
@@ -69,7 +72,7 @@ function SecretsTable({
       await updateSecret(secret._id, { token: undefined })
     } catch (e) {
       if (!e.warning) {
-        console.error(e)
+        toastDispatch(showToast(e.message, toastDispatch))
       }
     }
   }
@@ -91,7 +94,7 @@ function SecretsTable({
       await removeSecret(secret._id)
     } catch (e) {
       if (!e.warning) {
-        console.error(e)
+        toastDispatch(showToast(e.message, toastDispatch))
       }
     }
   }

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,0 +1,82 @@
+import React, { useContext } from 'react'
+import {
+  IconButton,
+  Snackbar,
+  SnackbarContent,
+  withStyles
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+import ErrorIcon from '@material-ui/icons/Error'
+
+import {
+  closeToast,
+  ToastDispatchContext,
+  ToastStateContext
+} from '../context/toast'
+
+function Toast({ classes }) {
+  const toastDispatch = useContext(ToastDispatchContext)
+  const { message, open } = useContext(ToastStateContext)
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    toastDispatch(closeToast())
+  }
+
+  return (
+    <div>
+      <Snackbar
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        open={open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+      >
+        <SnackbarContent
+          className={classes.error}
+          message={
+            <span className={classes.message}>
+              <ErrorIcon className={classes.iconVariant} />
+              {message}
+            </span>
+          }
+          action={[
+            <IconButton
+              key="close"
+              aria-label="Close"
+              color="inherit"
+              className={classes.close}
+              onClick={handleClose}
+            >
+              <CloseIcon className={classes.icon} />
+            </IconButton>
+          ]}
+        />
+      </Snackbar>
+    </div>
+  )
+}
+
+const styles = theme => ({
+  close: {
+    padding: theme.spacing.unit / 2
+  },
+  error: {
+    backgroundColor: theme.palette.error.dark
+  },
+  icon: {
+    fontSize: 20
+  },
+  iconVariant: {
+    opacity: 0.9,
+    marginRight: theme.spacing.unit
+  },
+  message: {
+    display: 'flex',
+    alignItems: 'center'
+  }
+})
+
+export default withStyles(styles)(Toast)

--- a/src/context/toast.js
+++ b/src/context/toast.js
@@ -1,0 +1,53 @@
+import React, { useReducer } from 'react'
+
+const initialState = {
+  open: false,
+  message: 'An unknown error occured'
+}
+
+export const ToastDispatchContext = React.createContext(null)
+export const ToastStateContext = React.createContext(initialState)
+
+const CLOSE_TOAST = 'CLOSE_TOAST'
+const OPEN_TOAST = 'OPEN_TOAST'
+const SET_TOAST_MESSAGE = 'SET_TOAST_MESSAGE'
+
+export const closeToast = function() {
+  return { type: CLOSE_TOAST }
+}
+
+export const showToast = function(message, dispatch) {
+  message = message || initialState.message
+  dispatch(setToastMessage(message))
+  return { type: OPEN_TOAST }
+}
+
+const setToastMessage = function(message) {
+  return { type: SET_TOAST_MESSAGE, payload: message }
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case CLOSE_TOAST:
+      return { ...state, open: false }
+    case OPEN_TOAST:
+      return { ...state, open: true }
+    case SET_TOAST_MESSAGE:
+      return { ...state, message: action.payload }
+    default:
+      console.log(`${action.type} is not a valid action`)
+      return { ...state }
+  }
+}
+
+export function ToastProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  return (
+    <ToastDispatchContext.Provider value={dispatch}>
+      <ToastStateContext.Provider value={state}>
+        {children}
+      </ToastStateContext.Provider>
+    </ToastDispatchContext.Provider>
+  )
+}

--- a/src/lib/qr-parser.js
+++ b/src/lib/qr-parser.js
@@ -14,14 +14,8 @@ export async function scan(file) {
 }
 
 export async function parse(content) {
-  try {
-    console.log('Got from image/QR code:', content)
-    const { issuer, key: secret, account } = otpauth.parse(content)
-    console.log(issuer, account, secret)
-    return { issuer, account, secret }
-  } catch (err) {
-    console.log(`Unparseable QR code: ${err.message}`, err)
-    // TODO throw error
-    return null
-  }
+  console.log('Got from image/QR code:', content)
+  const { issuer, key: secret, account } = otpauth.parse(content)
+  console.log(issuer, account, secret)
+  return { issuer, account, secret }
 }


### PR DESCRIPTION
Addresses #5 

This adds a Toast component and uses it to display error messages where possible. There are still some issues when trying to handle errors in the `Main` component. This is because the providers have not been rendered yet so the dispatch context is undefined. 

We may be able to create a `ProvidedMain` component that acts as Main (wrapping all other components) but has access to providers. Something like:  

```
<Main>
   <Provider1>
      <Provider2>
         <ProvidedMain>
            // app goes here
```