### PR TITLE
Security checks

### DIFF
--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -2,7 +2,7 @@
 
 const uniqid = require('uniqid')
 
-const approvalLimit = 10
+const approvalLimit = 60e3
 
 async function otpRoutes(server) {
   server.route({

--- a/server/lib/routes/token.js
+++ b/server/lib/routes/token.js
@@ -23,6 +23,20 @@ async function tokenRoutes(server) {
 
       const db = firebaseAdmin.firestore()
 
+      const subscriptionRef = await db
+        .collection('subscriptions')
+        .where(
+          firebaseAdmin.firestore.FieldPath.documentId(),
+          '==',
+          subscriptionId
+        )
+        .where('userId', '==', request.user)
+        .get()
+
+      if (subscriptionRef.empty) {
+        return reply.forbidden()
+      }
+
       const token = uniqid()
 
       await db

--- a/server/test/test-util.js
+++ b/server/test/test-util.js
@@ -17,6 +17,8 @@ async function buildServer(plugins = []) {
     server
   )
 
+  server.decorateRequest('user', '11111')
+
   await server.ready()
 
   return server

--- a/server/test/token.test.js
+++ b/server/test/token.test.js
@@ -56,12 +56,14 @@ test('token route', async (t) => {
     setStub.reset()
     deleteStub.reset()
     documentIdStub.reset()
+    getStub.reset()
   })
 
   t.teardown(server.close.bind(server))
 
   t.test('should set token for user', async (t) => {
     setStub.resolves()
+    getStub.resolves({ empty: false })
     const response = await server.inject({
       url: '/api/token',
       method: 'PUT',
@@ -94,6 +96,21 @@ test('token route', async (t) => {
 
     t.equal(response.statusCode, 400)
   })
+
+  t.test(
+    'should return 403 if subscriptionId doesnt belong to user',
+    async (t) => {
+      getStub.resolves({ empty: true })
+      const response = await server.inject({
+        url: '/api/token',
+        method: 'PUT',
+        body: { secretId: 'mock-id', subscriptionId: 'mock-subscription' }
+      })
+
+      t.equal(response.statusCode, 403)
+      t.equal(getStub.calledOnce, true)
+    }
+  )
 
   t.test('should delete token', async (t) => {
     deleteStub.resolves()


### PR DESCRIPTION
This PR adds user-related checks to `/api/token` and `/api/generate` endpoints to prevent unauthorized use.

Closes #47 