### PR TITLE
feat: multiple tokens per secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "eslint . --fix",
     "prettier": "prettier --write '**/*.js?(on)' '**/*.scss'",
     "start": "node server/index.js",
-    "test": "tap server/test/ --timeout=120 --no-coverage && react-app-rewired test --passWithNoTests",
+    "test": "tap server/test/ --no-coverage && react-app-rewired test --passWithNoTests",
     "prepare": "npx husky install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "prettier": "prettier --write '**/*.js?(on)' '**/*.scss'",
     "start": "node server/index.js",
     "test": "tap server/test/ --timeout=120 --no-coverage && react-app-rewired test --passWithNoTests",
-    "prepare": "npx husky install",
-    "temp": "tap server/test/otp.test.js --timeout=120 --no-coverage"
+    "prepare": "npx husky install"
   },
   "dependencies": {
     "@material-ui/core": "^3.9.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "prettier --write '**/*.js?(on)' '**/*.scss'",
     "start": "node server/index.js",
     "test": "tap server/test/ --timeout=120 --no-coverage && react-app-rewired test --passWithNoTests",
-    "prepare": "npx husky install"
+    "prepare": "npx husky install",
+    "temp": "tap server/test/otp.test.js --timeout=120 --no-coverage"
   },
   "dependencies": {
     "@material-ui/core": "^3.9.2",

--- a/server/lib/plugins/push.js
+++ b/server/lib/plugins/push.js
@@ -24,17 +24,20 @@ async function sendWebPush(log, { subscription, secretId, uniqueId }) {
   }
 }
 
-async function sendExpoPush(log, expo, { subscription, secretId, uniqueId }) {
-  const { token } = subscription
-  if (!Expo.isExpoPushToken(token)) {
-    log.error(`Push token ${token} is not a valid Expo push token`)
+async function sendExpoPush(
+  log,
+  expo,
+  { subscription, secretId, uniqueId, token }
+) {
+  if (!Expo.isExpoPushToken(subscription.token)) {
+    log.error(`Push token ${subscription.token} is not a valid Expo push token`)
     return
   }
 
   try {
     await expo.sendPushNotificationsAsync([
       {
-        to: token,
+        to: subscription.token,
         sound: 'default',
         body: 'One Time Password requested',
         data: { uniqueId, token, secretId }
@@ -58,8 +61,8 @@ async function pushPlugin(server, options) {
   const expo = new Expo()
 
   const push = {
-    send: async ({ subscription, secretId, uniqueId }) => {
-      const params = { subscription, secretId, uniqueId }
+    send: async ({ subscription, secretId, uniqueId, token }) => {
+      const params = { subscription, secretId, uniqueId, token }
       subscription.type === 'expo'
         ? sendExpoPush(log, expo, params)
         : sendWebPush(log, params)

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -82,7 +82,8 @@ async function otpRoutes(server) {
         push.send({
           subscription: subscription.data(),
           secretId,
-          uniqueId
+          uniqueId,
+          token
         })
 
         const timeout = setTimeout(completeRequest, approvalLimit)

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -17,9 +17,23 @@ async function otpRoutes(server) {
 
       const db = firebaseAdmin.firestore()
 
+      const tokenDataFromAllTokens = await db
+        .collection('allTokens')
+        .doc(token)
+        .get()
+
+      if (!tokenDataFromAllTokens.exists) {
+        log.error('Token not found in allTokens collection')
+        return reply.notFound('Token not found')
+      }
+
+      const { secretId } = tokenDataFromAllTokens.data()
+
       const secret = await db
+        .collection('secrets')
+        .doc(secretId)
         .collection('tokens')
-        .where('token', '==', token)
+        .doc(token)
         .get()
 
       if (secret.empty) {
@@ -27,8 +41,7 @@ async function otpRoutes(server) {
         return reply.notFound('Token not found')
       }
 
-      const { subscriptionId } = secret.docs[0].data()
-      const secretId = secret.docs[0].id
+      const { subscriptionId } = secret.data()
 
       const subscription = await db
         .collection('subscriptions')

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -18,12 +18,12 @@ async function otpRoutes(server) {
       const db = firebaseAdmin.firestore()
 
       const tokenData = await db
-        .collection('allTokens')
+        .collection('tokens')
         .doc(token)
         .get()
 
       if (!tokenData.exists) {
-        log.error('Token not found in allTokens collection')
+        log.error('Token not found in tokens collection')
         return reply.notFound('Token not found')
       }
 

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -17,31 +17,17 @@ async function otpRoutes(server) {
 
       const db = firebaseAdmin.firestore()
 
-      const tokenDataFromAllTokens = await db
+      const tokenData = await db
         .collection('allTokens')
         .doc(token)
         .get()
 
-      if (!tokenDataFromAllTokens.exists) {
+      if (!tokenData.exists) {
         log.error('Token not found in allTokens collection')
         return reply.notFound('Token not found')
       }
 
-      const { secretId } = tokenDataFromAllTokens.data()
-
-      const secret = await db
-        .collection('secrets')
-        .doc(secretId)
-        .collection('tokens')
-        .doc(token)
-        .get()
-
-      if (secret.empty) {
-        log.error('Token not found')
-        return reply.notFound('Token not found')
-      }
-
-      const { subscriptionId } = secret.data()
+      const { secretId, subscriptionId } = tokenData.data()
 
       const subscription = await db
         .collection('subscriptions')

--- a/server/lib/routes/secret.js
+++ b/server/lib/routes/secret.js
@@ -18,7 +18,7 @@ async function deleteTokenIfAuthorized(
   }
 
   await db
-    .collection('allTokens')
+    .collection('tokens')
     .doc(tokenId)
     .delete()
 
@@ -37,7 +37,7 @@ async function secretRoutes(server) {
       const db = firebaseAdmin.firestore()
 
       const tokensForSecret = await db
-        .collection('allTokens')
+        .collection('tokens')
         .where('secretId', '==', secretId)
         .get()
 

--- a/server/lib/routes/secret.js
+++ b/server/lib/routes/secret.js
@@ -45,7 +45,7 @@ async function secretRoutes(server) {
         return reply.notFound('Secret not found')
       }
 
-      let deletedError = false
+      let deleteAuthenticationError = false
 
       for await (const didDelete of await tokensForSecret.docs.map((doc) =>
         deleteTokenIfAuthorized(
@@ -56,11 +56,11 @@ async function secretRoutes(server) {
         )
       )) {
         if (!didDelete) {
-          deletedError = true
+          deleteAuthenticationError = true
         }
       }
 
-      if (deletedError) {
+      if (deleteAuthenticationError) {
         return reply.forbidden('Not authorized')
       } else {
         reply.code(204).send()

--- a/server/lib/routes/secret.js
+++ b/server/lib/routes/secret.js
@@ -1,0 +1,50 @@
+'use strict'
+
+async function secretRoutes(server) {
+  server.route({
+    method: 'DELETE',
+    url: '/api/secret/:secretId',
+    preHandler: server.auth([server.authenticate]),
+    handler: async (request, reply) => {
+      const { firebaseAdmin } = server
+      const { secretId } = request.params
+
+      const db = firebaseAdmin.firestore()
+
+      const tokensForSecretRef = await db
+        .collection('allTokens')
+        .where('secretId', '==', secretId)
+        .get()
+
+      if (tokensForSecretRef.empty) {
+        return reply.notFound('Secret not found')
+      }
+
+      // TODO will need to iterate over each token and remove where matches secret
+      // const subscriptionId = tokensForSecretRef.get('subscriptionId')
+      //
+      // const subscriptionRef = await db
+      //   .collection('subscriptions')
+      //   .where(
+      //     firebaseAdmin.firestore.FieldPath.documentId(),
+      //     '==',
+      //     subscriptionId
+      //   )
+      //   .where('userId', '==', request.user)
+      //   .get()
+      //
+      // if (subscriptionRef.empty) {
+      //   return reply.forbidden('Not authorized')
+      // }
+      //
+      // await db
+      //   .collection('allTokens')
+      //   .where('secretId', '==', secretId)
+      //   .delete()
+
+      reply.code(204).send()
+    }
+  })
+}
+
+module.exports = secretRoutes

--- a/server/lib/routes/token.js
+++ b/server/lib/routes/token.js
@@ -48,6 +48,7 @@ async function tokenRoutes(server) {
           .delete()
         await db
           .collection('secrets')
+          .doc(secretId)
           .collection('tokens')
           .doc(token)
           .delete()

--- a/server/lib/routes/token.js
+++ b/server/lib/routes/token.js
@@ -48,7 +48,6 @@ async function tokenRoutes(server) {
           .delete()
       }
 
-      // Store tokens as a top level object to allow easy access via `secretId`
       await db
         .collection('allTokens')
         .doc(token)

--- a/server/lib/routes/token.js
+++ b/server/lib/routes/token.js
@@ -43,13 +43,13 @@ async function tokenRoutes(server) {
       // Remove the existing token if specified (refreshing token)
       if (existingToken) {
         await db
-          .collection('allTokens')
+          .collection('tokens')
           .doc(existingToken)
           .delete()
       }
 
       await db
-        .collection('allTokens')
+        .collection('tokens')
         .doc(token)
         .set({
           secretId,
@@ -71,7 +71,7 @@ async function tokenRoutes(server) {
       const db = firebaseAdmin.firestore()
 
       const tokenRef = await db
-        .collection('allTokens')
+        .collection('tokens')
         .doc(tokenId)
         .get()
 
@@ -96,7 +96,7 @@ async function tokenRoutes(server) {
       }
 
       await db
-        .collection('allTokens')
+        .collection('tokens')
         .doc(tokenId)
         .delete()
 

--- a/server/test/secret.test.js
+++ b/server/test/secret.test.js
@@ -1,0 +1,81 @@
+const { test } = require('tap')
+const sinon = require('sinon')
+
+const tokenRoutes = require('../lib/routes/token')
+
+const { buildServer, decorate } = require('./test-util.js')
+
+test('secret route', async (t) => {
+  const authStub = sinon.stub()
+  const sendStub = sinon.stub()
+  const setStub = sinon.stub()
+  const deleteStub = sinon.stub()
+  const getStub = sinon.stub()
+  const documentIdStub = sinon.stub()
+
+  const mockedAuthPlugin = async function(server) {
+    decorate(server, 'auth', authStub)
+  }
+
+  const mockedFirebasePlugin = async function(server) {
+    const admin = {
+      firestore: () => ({
+        collection: () => ({
+          doc: () => ({
+            get: getStub,
+            set: setStub,
+            delete: deleteStub
+          }),
+          where: () => ({
+            where: () => ({
+              get: getStub
+            })
+          })
+        })
+      })
+    }
+    admin.firestore.FieldPath = { documentId: documentIdStub }
+    decorate(server, 'firebaseAdmin', admin)
+  }
+
+  const mockedPushPlugin = async function(server) {
+    const push = {
+      send: sendStub
+    }
+    decorate(server, 'push', push)
+  }
+
+  const server = await buildServer([
+    { plugin: mockedAuthPlugin },
+    { plugin: mockedFirebasePlugin },
+    { plugin: mockedPushPlugin },
+    { plugin: tokenRoutes }
+  ])
+
+  t.beforeEach(async () => {
+    setStub.reset()
+    deleteStub.reset()
+    documentIdStub.reset()
+    getStub.reset()
+  })
+
+  t.teardown(server.close.bind(server))
+
+  t.test('should delete all tokens relating to a secretId', async (t) => {
+    deleteStub.resolves()
+    getStub.onCall(0).resolves({
+      exists: true,
+      get: () => '111'
+    })
+    getStub.onCall(1).resolves({ empty: false })
+    documentIdStub.resolves('111')
+
+    const response = await server.inject({
+      url: '/api/token/55555',
+      method: 'DELETE'
+    })
+
+    t.equal(response.statusCode, 204)
+    t.equal(deleteStub.calledOnce, true)
+  })
+})

--- a/server/test/token.test.js
+++ b/server/test/token.test.js
@@ -72,7 +72,7 @@ test('token route', async (t) => {
 
     const data = response.json()
 
-    // t.equal(response.statusCode, 200)
+    t.equal(response.statusCode, 200)
     t.equal(setStub.calledOnce, true)
     t.equal(data.hasOwnProperty('token'), true)
   })

--- a/server/test/token.test.js
+++ b/server/test/token.test.js
@@ -18,20 +18,24 @@ test('token route', async (t) => {
   }
 
   const mockedFirebasePlugin = async function(server) {
+    const collection = () => ({
+      doc: () => ({
+        get: getStub,
+        set: setStub,
+        delete: deleteStub,
+        collection
+      }),
+      where: () => ({
+        where: () => ({
+          get: getStub
+        }),
+        delete: deleteStub
+      })
+    })
+
     const admin = {
       firestore: () => ({
-        collection: () => ({
-          doc: () => ({
-            get: getStub,
-            set: setStub,
-            delete: deleteStub
-          }),
-          where: () => ({
-            where: () => ({
-              get: getStub
-            })
-          })
-        })
+        collection
       })
     }
     admin.firestore.FieldPath = { documentId: documentIdStub }
@@ -73,7 +77,7 @@ test('token route', async (t) => {
     const data = response.json()
 
     t.equal(response.statusCode, 200)
-    t.equal(setStub.calledOnce, true)
+    t.equal(setStub.calledTwice, true)
     t.equal(data.hasOwnProperty('token'), true)
   })
 
@@ -127,6 +131,6 @@ test('token route', async (t) => {
     })
 
     t.equal(response.statusCode, 204)
-    t.equal(deleteStub.calledOnce, true)
+    t.equal(deleteStub.calledTwice, true)
   })
 })

--- a/server/test/token.test.js
+++ b/server/test/token.test.js
@@ -18,24 +18,20 @@ test('token route', async (t) => {
   }
 
   const mockedFirebasePlugin = async function(server) {
-    const collection = () => ({
-      doc: () => ({
-        get: getStub,
-        set: setStub,
-        delete: deleteStub,
-        collection
-      }),
-      where: () => ({
-        where: () => ({
-          get: getStub
-        }),
-        delete: deleteStub
-      })
-    })
-
     const admin = {
       firestore: () => ({
-        collection
+        collection: () => ({
+          doc: () => ({
+            get: getStub,
+            set: setStub,
+            delete: deleteStub
+          }),
+          where: () => ({
+            where: () => ({
+              get: getStub
+            })
+          })
+        })
       })
     }
     admin.firestore.FieldPath = { documentId: documentIdStub }
@@ -76,8 +72,8 @@ test('token route', async (t) => {
 
     const data = response.json()
 
-    t.equal(response.statusCode, 200)
-    t.equal(setStub.calledTwice, true)
+    // t.equal(response.statusCode, 200)
+    t.equal(setStub.calledOnce, true)
     t.equal(data.hasOwnProperty('token'), true)
   })
 
@@ -131,6 +127,6 @@ test('token route', async (t) => {
     })
 
     t.equal(response.statusCode, 204)
-    t.equal(deleteStub.calledTwice, true)
+    t.equal(deleteStub.calledOnce, true)
   })
 })


### PR DESCRIPTION
Updates the firebase data model to allow for multiple tokens per secret by creating a `allTokens` top level collection that is has a `secretId` and `subscriptionId` that is optimised for finding a token quickly. The tokens `PUT` endpoint is updated to take an optional existing token and this allows revoking a single token (by deleting the existing token and creating a new one).

A new route has been added to allow deleting secrets. This will delete all tokens that contain the token id. Each delete checks to ensure that the correct subscription id associated with the user is also associated with the token to ensure that they only delete tokens that they are managing.

This PR also fixes the token that is pushed on an OTP request to the correct token. Currently it's sending the expo subscription token.

In addition some improvements were made to the test by using sinon's fake timers to fake the setTimeout and allowed removing the timeout from the test npm script.