### PR TITLE
feat: update notify-release config

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  issues:
+    types: [closed]
   schedule:
     - cron: '30 8 * * *'
 jobs:


### PR DESCRIPTION
This PR adds the on closed issues trigger to the notify-release action, in order to handle the creation of a comment when a notify-release issue is snoozed.