### PR TITLE
feat: updated deploy job to use GCP secrets action

### DIFF
--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -52,10 +52,11 @@ jobs:
           project_id: ${{ secrets.gcp_project_id }}
 
       - id: update-secrets
-        run: |
-          if [ "${{ secrets.firebase_private_key_base64 }}" != "$(gcloud secrets versions access latest --secret ${{ secrets.firebase_private_key_base64_gcp_secret_name }})" ]; then
-            echo "${{ secrets.firebase_private_key_base64 }}" | tr -d '\n' | gcloud secrets versions add ${{ secrets.firebase_private_key_base64_gcp_secret_name }} --data-file=-
-          fi
+        uses: nearform-actions/github-action-gcp-secrets@v1
+        with:
+          secrets: |-
+            ${{ secrets.firebase_private_key_base64_gcp_secret_name }}:"${{ secrets.firebase_private_key_base64 }}"
+
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v1
         with:


### PR DESCRIPTION
Closes https://github.com/nearform/optic/issues/261

Updated deploy job to use [`nearform-actions/github-action-gcp-secrets@v1`](https://github.com/nearform-actions/github-action-gcp-secrets)

This action handles the existing check of whether the value has changed and needs updating.

Because we make use of the YAML block chomping indicator `|-` this should remove any trailing newline characters from the secrets value as per the previous inline script implementation.