### PR TITLE
feat: add support for package info when sending otp request

### DIFF
--- a/server/lib/plugins/push.js
+++ b/server/lib/plugins/push.js
@@ -6,7 +6,7 @@ const { Expo } = require('expo-server-sdk')
 async function sendExpoPush(
   log,
   expo,
-  { subscription, secretId, uniqueId, token }
+  { subscription, secretId, uniqueId, token, packageInfo }
 ) {
   if (!Expo.isExpoPushToken(subscription.token)) {
     log.error(`Push token ${subscription.token} is not a valid Expo push token`)
@@ -19,7 +19,7 @@ async function sendExpoPush(
         to: subscription.token,
         sound: 'default',
         body: 'One Time Password requested',
-        data: { uniqueId, token, secretId }
+        data: { uniqueId, token, secretId, packageInfo }
       }
     ])
   } catch (error) {
@@ -34,8 +34,8 @@ async function pushPlugin(server, options) {
   const expo = new Expo()
 
   const push = {
-    send: async ({ subscription, secretId, uniqueId, token }) => {
-      const params = { subscription, secretId, uniqueId, token }
+    send: async ({ subscription, secretId, uniqueId, token, packageInfo }) => {
+      const params = { subscription, secretId, uniqueId, token, packageInfo }
       sendExpoPush(log, expo, params)
     }
   }

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -5,7 +5,92 @@ const uniqid = require('uniqid')
 const approvalLimit = 60e3
 
 async function otpRoutes(server) {
-  const otpRequestMethods = ['GET', 'POST']
+  const generateTokenHandler = async (request, reply) => {
+    const { firebaseAdmin, push } = server
+    const {
+      params: { token },
+      log,
+      body = { packageInfo: {} }
+    } = request
+
+    const db = firebaseAdmin.firestore()
+
+    const tokenData = await db.collection('tokens').doc(token).get()
+
+    if (!tokenData.exists) {
+      log.error('Token not found in tokens collection')
+      return reply.notFound('Token not found')
+    }
+
+    const { secretId, subscriptionId } = tokenData.data()
+
+    const subscription = await db
+      .collection('subscriptions')
+      .doc(subscriptionId)
+      .get()
+
+    if (!subscription.exists) {
+      log.error(`Subscription not found - ${subscriptionId}`)
+      return reply.notFound('Subscription not found')
+    }
+
+    const uniqueId = uniqid()
+
+    return new Promise(() => {
+      const requestObj = db.collection('requests').doc(uniqueId)
+      requestObj.set({ createdAt: new Date() })
+
+      const completeRequest = (error, otp) => {
+        requestObj.delete()
+        if (error) {
+          log.error(error.message)
+          return reply.internalServerError()
+        }
+
+        unsubscribe()
+        clearTimeout(timeout)
+
+        if (!otp) {
+          log.error('Request was not approved')
+          return reply.forbidden('Request was not approved')
+        }
+
+        log.info('Request approved, sending back OTP')
+        return reply.send(otp)
+      }
+
+      const unsubscribe = requestObj.onSnapshot(
+        (update) => {
+          const approved = update.get('approved')
+          if (approved === undefined) {
+            // update due to object creation
+            return
+          }
+          completeRequest(null, update.get('otp'))
+        },
+        (error) => {
+          log.error(error.message)
+          return reply.internalServerError()
+        }
+      )
+
+      const notification = {
+        subscription: subscription.data(),
+        secretId,
+        uniqueId,
+        token
+      }
+
+      if (body.packageInfo) {
+        notification.packageInfo = { ...body.packageInfo }
+      }
+
+      push.send(notification)
+
+      const timeout = setTimeout(completeRequest, approvalLimit)
+    })
+  }
+
   /**
    * @deprecated GET /api/generate/:token
    *
@@ -15,113 +100,33 @@ async function otpRoutes(server) {
    * The GET request is here just to maintain backwards compatibility and
    * should be removed in the future.
    */
-  otpRequestMethods.forEach((method) => {
-    server.route({
-      method,
-      url: '/api/generate/:token',
-      handler: async (request, reply) => {
-        const { firebaseAdmin, push } = server
-        const {
-          params: { token },
-          log,
-          body = { packageInfo: {} }
-        } = request
+  server.route({
+    method: 'GET',
+    url: '/api/generate/:token',
+    handler: generateTokenHandler
+  })
 
-        const db = firebaseAdmin.firestore()
-
-        const tokenData = await db.collection('tokens').doc(token).get()
-
-        if (!tokenData.exists) {
-          log.error('Token not found in tokens collection')
-          return reply.notFound('Token not found')
-        }
-
-        const { secretId, subscriptionId } = tokenData.data()
-
-        const subscription = await db
-          .collection('subscriptions')
-          .doc(subscriptionId)
-          .get()
-
-        if (!subscription.exists) {
-          log.error(`Subscription not found - ${subscriptionId}`)
-          return reply.notFound('Subscription not found')
-        }
-
-        const uniqueId = uniqid()
-
-        return new Promise(() => {
-          const requestObj = db.collection('requests').doc(uniqueId)
-          requestObj.set({ createdAt: new Date() })
-
-          const completeRequest = (error, otp) => {
-            requestObj.delete()
-            if (error) {
-              log.error(error.message)
-              return reply.internalServerError()
-            }
-
-            unsubscribe()
-            clearTimeout(timeout)
-
-            if (!otp) {
-              log.error('Request was not approved')
-              return reply.forbidden('Request was not approved')
-            }
-
-            log.info('Request approved, sending back OTP')
-            return reply.send(otp)
-          }
-
-          const unsubscribe = requestObj.onSnapshot(
-            (update) => {
-              const approved = update.get('approved')
-              if (approved === undefined) {
-                // update due to object creation
-                return
-              }
-              completeRequest(null, update.get('otp'))
+  server.route({
+    method: 'POST',
+    url: '/api/generate/:token',
+    handler: generateTokenHandler,
+    schema: {
+      body: {
+        type: ['object', 'null'],
+        properties: {
+          packageInfo: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              version: { type: 'string' }
             },
-            (error) => {
-              log.error(error.message)
-              return reply.internalServerError()
-            }
-          )
-
-          const notification = {
-            subscription: subscription.data(),
-            secretId,
-            uniqueId,
-            token
+            required: ['name', 'version'],
+            additionalProperties: false
           }
-
-          if (body.packageInfo) {
-            notification.packageInfo = { ...body.packageInfo }
-          }
-
-          push.send(notification)
-
-          const timeout = setTimeout(completeRequest, approvalLimit)
-        })
-      },
-      schema: method === 'POST' && {
-        body: {
-          type: ['object', 'null'],
-          properties: {
-            packageInfo: {
-              type: 'object',
-              properties: {
-                name: { type: 'string' },
-                version: { type: 'string' }
-              },
-              required: ['name', 'version'],
-              additionalProperties: false
-            }
-          },
-          additionalProperties: false
-        }
+        },
+        additionalProperties: false
       }
-    })
+    }
   })
 
   server.post('/api/respond', async (request, reply) => {

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -4,88 +4,107 @@ const uniqid = require('uniqid')
 
 const approvalLimit = 60e3
 
+const generateOtpHandler = (server) => async (request, reply) => {
+  const { firebaseAdmin, push } = server
+  const {
+    params: { token },
+    log,
+    body = {}
+  } = request
+
+  const db = firebaseAdmin.firestore()
+
+  const tokenData = await db.collection('tokens').doc(token).get()
+
+  if (!tokenData.exists) {
+    log.error('Token not found in tokens collection')
+    return reply.notFound('Token not found')
+  }
+
+  const { secretId, subscriptionId } = tokenData.data()
+
+  const subscription = await db
+    .collection('subscriptions')
+    .doc(subscriptionId)
+    .get()
+
+  if (!subscription.exists) {
+    log.error(`Subscription not found - ${subscriptionId}`)
+    return reply.notFound('Subscription not found')
+  }
+
+  const uniqueId = uniqid()
+
+  return new Promise(() => {
+    const requestObj = db.collection('requests').doc(uniqueId)
+    requestObj.set({ createdAt: new Date() })
+
+    const completeRequest = (error, otp) => {
+      requestObj.delete()
+      if (error) {
+        log.error(error.message)
+        return reply.internalServerError()
+      }
+
+      unsubscribe()
+      clearTimeout(timeout)
+
+      if (!otp) {
+        log.error('Request was not approved')
+        return reply.forbidden('Request was not approved')
+      }
+
+      log.info('Request approved, sending back OTP')
+      return reply.send(otp)
+    }
+
+    const unsubscribe = requestObj.onSnapshot(
+      (update) => {
+        const approved = update.get('approved')
+        if (approved === undefined) {
+          // update due to object creation
+          return
+        }
+        completeRequest(null, update.get('otp'))
+      },
+      (error) => {
+        log.error(error.message)
+        return reply.internalServerError()
+      }
+    )
+
+    push.send({
+      subscription: subscription.data(),
+      secretId,
+      uniqueId,
+      token,
+      packageInfo: {
+        ...(body.version && { version: body.version }),
+        ...(body.name && { name: body.name })
+      }
+    })
+
+    const timeout = setTimeout(completeRequest, approvalLimit)
+  })
+}
+
 async function otpRoutes(server) {
+  server.route({
+    method: 'POST',
+    url: '/api/generate/:token',
+    handler: generateOtpHandler(server)
+  })
+
+  /**
+   * @deprecated From now on the generate otp route will be a POST request
+   * allowing the user to send more information about the OTP request such
+   * as package name and version being deployed.
+   * The GET request is here just to maintain backwards compatibility
+   */
   server.route({
     method: 'GET',
     url: '/api/generate/:token',
-    handler: async (request, reply) => {
-      const { firebaseAdmin, push } = server
-      const {
-        params: { token },
-        log
-      } = request
-
-      const db = firebaseAdmin.firestore()
-
-      const tokenData = await db.collection('tokens').doc(token).get()
-
-      if (!tokenData.exists) {
-        log.error('Token not found in tokens collection')
-        return reply.notFound('Token not found')
-      }
-
-      const { secretId, subscriptionId } = tokenData.data()
-
-      const subscription = await db
-        .collection('subscriptions')
-        .doc(subscriptionId)
-        .get()
-
-      if (!subscription.exists) {
-        log.error(`Subscription not found - ${subscriptionId}`)
-        return reply.notFound('Subscription not found')
-      }
-
-      const uniqueId = uniqid()
-
-      return new Promise(() => {
-        const requestObj = db.collection('requests').doc(uniqueId)
-        requestObj.set({ createdAt: new Date() })
-
-        const completeRequest = (error, otp) => {
-          requestObj.delete()
-          if (error) {
-            log.error(error.message)
-            return reply.internalServerError()
-          }
-
-          unsubscribe()
-          clearTimeout(timeout)
-
-          if (!otp) {
-            log.error('Request was not approved')
-            return reply.forbidden('Request was not approved')
-          }
-
-          log.info('Request approved, sending back OTP')
-          return reply.send(otp)
-        }
-
-        const unsubscribe = requestObj.onSnapshot(
-          (update) => {
-            const approved = update.get('approved')
-            if (approved === undefined) {
-              // update due to object creation
-              return
-            }
-            completeRequest(null, update.get('otp'))
-          },
-          (error) => {
-            log.error(error.message)
-            return reply.internalServerError()
-          }
-        )
-
-        push.send({
-          subscription: subscription.data(),
-          secretId,
-          uniqueId,
-          token
-        })
-
-        const timeout = setTimeout(completeRequest, approvalLimit)
-      })
-    }
+    handler: generateOtpHandler(server)
   })
 
   server.post('/api/respond', async (request, reply) => {

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -5,202 +5,123 @@ const uniqid = require('uniqid')
 const approvalLimit = 60e3
 
 async function otpRoutes(server) {
+  const otpRequestMethods = ['GET', 'POST']
   /**
    * @deprecated GET /api/generate/:token
    *
    * From now on the generate otp route will be a POST request
    * allowing the user to send more information about the OTP request such
    * as package name and version being deployed.
-   * The GET request is here just to maintain backwards compatibility
+   * The GET request is here just to maintain backwards compatibility and
+   * should be removed in the future.
    */
-  server.route({
-    method: 'GET',
-    url: '/api/generate/:token',
-    handler: async (request, reply) => {
-      const { firebaseAdmin, push } = server
-      const {
-        params: { token },
-        log
-      } = request
+  otpRequestMethods.forEach((method) => {
+    server.route({
+      method,
+      url: '/api/generate/:token',
+      handler: async (request, reply) => {
+        const { firebaseAdmin, push } = server
+        const {
+          params: { token },
+          log,
+          body = { packageInfo: {} }
+        } = request
 
-      const db = firebaseAdmin.firestore()
+        const db = firebaseAdmin.firestore()
 
-      const tokenData = await db.collection('tokens').doc(token).get()
+        const tokenData = await db.collection('tokens').doc(token).get()
 
-      if (!tokenData.exists) {
-        log.error('Token not found in tokens collection')
-        return reply.notFound('Token not found')
-      }
-
-      const { secretId, subscriptionId } = tokenData.data()
-
-      const subscription = await db
-        .collection('subscriptions')
-        .doc(subscriptionId)
-        .get()
-
-      if (!subscription.exists) {
-        log.error(`Subscription not found - ${subscriptionId}`)
-        return reply.notFound('Subscription not found')
-      }
-
-      const uniqueId = uniqid()
-
-      return new Promise(() => {
-        const requestObj = db.collection('requests').doc(uniqueId)
-        requestObj.set({ createdAt: new Date() })
-
-        const completeRequest = (error, otp) => {
-          requestObj.delete()
-          if (error) {
-            log.error(error.message)
-            return reply.internalServerError()
-          }
-
-          unsubscribe()
-          clearTimeout(timeout)
-
-          if (!otp) {
-            log.error('Request was not approved')
-            return reply.forbidden('Request was not approved')
-          }
-
-          log.info('Request approved, sending back OTP')
-          return reply.send(otp)
+        if (!tokenData.exists) {
+          log.error('Token not found in tokens collection')
+          return reply.notFound('Token not found')
         }
 
-        const unsubscribe = requestObj.onSnapshot(
-          (update) => {
-            const approved = update.get('approved')
-            if (approved === undefined) {
-              // update due to object creation
-              return
+        const { secretId, subscriptionId } = tokenData.data()
+
+        const subscription = await db
+          .collection('subscriptions')
+          .doc(subscriptionId)
+          .get()
+
+        if (!subscription.exists) {
+          log.error(`Subscription not found - ${subscriptionId}`)
+          return reply.notFound('Subscription not found')
+        }
+
+        const uniqueId = uniqid()
+
+        return new Promise(() => {
+          const requestObj = db.collection('requests').doc(uniqueId)
+          requestObj.set({ createdAt: new Date() })
+
+          const completeRequest = (error, otp) => {
+            requestObj.delete()
+            if (error) {
+              log.error(error.message)
+              return reply.internalServerError()
             }
-            completeRequest(null, update.get('otp'))
-          },
-          (error) => {
-            log.error(error.message)
-            return reply.internalServerError()
-          }
-        )
 
-        push.send({
-          subscription: subscription.data(),
-          secretId,
-          uniqueId,
-          token
-        })
+            unsubscribe()
+            clearTimeout(timeout)
 
-        const timeout = setTimeout(completeRequest, approvalLimit)
-      })
-    }
-  })
-
-  server.route({
-    method: 'POST',
-    url: '/api/generate/:token',
-    handler: async (request, reply) => {
-      const { firebaseAdmin, push } = server
-      const {
-        params: { token },
-        log,
-        body = { packageInfo: {} }
-      } = request
-
-      const db = firebaseAdmin.firestore()
-
-      const tokenData = await db.collection('tokens').doc(token).get()
-
-      if (!tokenData.exists) {
-        log.error('Token not found in tokens collection')
-        return reply.notFound('Token not found')
-      }
-
-      const { secretId, subscriptionId } = tokenData.data()
-
-      const subscription = await db
-        .collection('subscriptions')
-        .doc(subscriptionId)
-        .get()
-
-      if (!subscription.exists) {
-        log.error(`Subscription not found - ${subscriptionId}`)
-        return reply.notFound('Subscription not found')
-      }
-
-      const uniqueId = uniqid()
-
-      return new Promise(() => {
-        const requestObj = db.collection('requests').doc(uniqueId)
-        requestObj.set({ createdAt: new Date() })
-
-        const completeRequest = (error, otp) => {
-          requestObj.delete()
-          if (error) {
-            log.error(error.message)
-            return reply.internalServerError()
-          }
-
-          unsubscribe()
-          clearTimeout(timeout)
-
-          if (!otp) {
-            log.error('Request was not approved')
-            return reply.forbidden('Request was not approved')
-          }
-
-          log.info('Request approved, sending back OTP')
-          return reply.send(otp)
-        }
-
-        const unsubscribe = requestObj.onSnapshot(
-          (update) => {
-            const approved = update.get('approved')
-            if (approved === undefined) {
-              // update due to object creation
-              return
+            if (!otp) {
+              log.error('Request was not approved')
+              return reply.forbidden('Request was not approved')
             }
-            completeRequest(null, update.get('otp'))
-          },
-          (error) => {
-            log.error(error.message)
-            return reply.internalServerError()
+
+            log.info('Request approved, sending back OTP')
+            return reply.send(otp)
           }
-        )
 
-        const notification = {
-          subscription: subscription.data(),
-          secretId,
-          uniqueId,
-          token
-        }
-
-        if (body.packageInfo) {
-          notification.packageInfo = { ...body.packageInfo }
-        }
-
-        push.send(notification)
-
-        const timeout = setTimeout(completeRequest, approvalLimit)
-      })
-    },
-    schema: {
-      body: {
-        type: ['object', 'null'],
-        properties: {
-          packageInfo: {
-            type: 'object',
-            properties: {
-              name: { type: 'string' },
-              version: { type: 'string' }
+          const unsubscribe = requestObj.onSnapshot(
+            (update) => {
+              const approved = update.get('approved')
+              if (approved === undefined) {
+                // update due to object creation
+                return
+              }
+              completeRequest(null, update.get('otp'))
             },
-            required: ['name', 'version'],
-            additionalProperties: false
+            (error) => {
+              log.error(error.message)
+              return reply.internalServerError()
+            }
+          )
+
+          const notification = {
+            subscription: subscription.data(),
+            secretId,
+            uniqueId,
+            token
           }
-        },
-        additionalProperties: false
+
+          if (body.packageInfo) {
+            notification.packageInfo = { ...body.packageInfo }
+          }
+
+          push.send(notification)
+
+          const timeout = setTimeout(completeRequest, approvalLimit)
+        })
+      },
+      schema: method === 'POST' && {
+        body: {
+          type: ['object', 'null'],
+          properties: {
+            packageInfo: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                version: { type: 'string' }
+              },
+              required: ['name', 'version'],
+              additionalProperties: false
+            }
+          },
+          additionalProperties: false
+        }
       }
-    }
+    })
   })
 
   server.post('/api/respond', async (request, reply) => {

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -79,18 +79,17 @@ const generateOtpHandler = (server) => async (request, reply) => {
       subscription: subscription.data(),
       secretId,
       uniqueId,
-      token,
+      token
     }
 
     const hasPackageInfo = !!name || !!version
 
     if (hasPackageInfo) {
       notification.packageInfo = {
-          ...(version && { version }),
-          ...(name && { name })
-        }
+        ...(version && { version }),
+        ...(name && { name })
       }
-
+    }
 
     push.send(notification)
 

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -5,27 +5,6 @@ const uniqid = require('uniqid')
 const approvalLimit = 60e3
 
 async function otpRoutes(server) {
-  const getSchemaForMetod = (method) =>
-    method === 'POST'
-      ? {
-          body: {
-            type: ['object', 'null'],
-            properties: {
-              packageInfo: {
-                type: 'object',
-                properties: {
-                  name: { type: 'string' },
-                  version: { type: 'string' }
-                },
-                required: ['name', 'version'],
-                additionalProperties: false
-              }
-            },
-            additionalProperties: false
-          }
-        }
-      : {}
-
   /**
    * @deprecated GET /api/generate/:token
    *
@@ -34,97 +13,194 @@ async function otpRoutes(server) {
    * as package name and version being deployed.
    * The GET request is here just to maintain backwards compatibility
    */
-  ;['GET', 'POST'].map((method) => {
-    server.route({
-      method,
-      url: '/api/generate/:token',
-      schema: getSchemaForMetod(method),
-      handler: async (request, reply) => {
-        const { firebaseAdmin, push } = server
-        const {
-          params: { token },
-          log,
-          body = { packageInfo: {} }
-        } = request
+  server.route({
+    method: 'GET',
+    url: '/api/generate/:token',
+    handler: async (request, reply) => {
+      const { firebaseAdmin, push } = server
+      const {
+        params: { token },
+        log
+      } = request
 
-        const db = firebaseAdmin.firestore()
+      const db = firebaseAdmin.firestore()
 
-        const tokenData = await db.collection('tokens').doc(token).get()
+      const tokenData = await db.collection('tokens').doc(token).get()
 
-        if (!tokenData.exists) {
-          log.error('Token not found in tokens collection')
-          return reply.notFound('Token not found')
-        }
-
-        const { secretId, subscriptionId } = tokenData.data()
-
-        const subscription = await db
-          .collection('subscriptions')
-          .doc(subscriptionId)
-          .get()
-
-        if (!subscription.exists) {
-          log.error(`Subscription not found - ${subscriptionId}`)
-          return reply.notFound('Subscription not found')
-        }
-
-        const uniqueId = uniqid()
-
-        return new Promise(() => {
-          const requestObj = db.collection('requests').doc(uniqueId)
-          requestObj.set({ createdAt: new Date() })
-
-          const completeRequest = (error, otp) => {
-            requestObj.delete()
-            if (error) {
-              log.error(error.message)
-              return reply.internalServerError()
-            }
-
-            unsubscribe()
-            clearTimeout(timeout)
-
-            if (!otp) {
-              log.error('Request was not approved')
-              return reply.forbidden('Request was not approved')
-            }
-
-            log.info('Request approved, sending back OTP')
-            return reply.send(otp)
-          }
-
-          const unsubscribe = requestObj.onSnapshot(
-            (update) => {
-              const approved = update.get('approved')
-              if (approved === undefined) {
-                // update due to object creation
-                return
-              }
-              completeRequest(null, update.get('otp'))
-            },
-            (error) => {
-              log.error(error.message)
-              return reply.internalServerError()
-            }
-          )
-
-          const notification = {
-            subscription: subscription.data(),
-            secretId,
-            uniqueId,
-            token
-          }
-
-          if (!!body.packageInfo) {
-            notification.packageInfo = { ...body.packageInfo }
-          }
-
-          push.send(notification)
-
-          const timeout = setTimeout(completeRequest, approvalLimit)
-        })
+      if (!tokenData.exists) {
+        log.error('Token not found in tokens collection')
+        return reply.notFound('Token not found')
       }
-    })
+
+      const { secretId, subscriptionId } = tokenData.data()
+
+      const subscription = await db
+        .collection('subscriptions')
+        .doc(subscriptionId)
+        .get()
+
+      if (!subscription.exists) {
+        log.error(`Subscription not found - ${subscriptionId}`)
+        return reply.notFound('Subscription not found')
+      }
+
+      const uniqueId = uniqid()
+
+      return new Promise(() => {
+        const requestObj = db.collection('requests').doc(uniqueId)
+        requestObj.set({ createdAt: new Date() })
+
+        const completeRequest = (error, otp) => {
+          requestObj.delete()
+          if (error) {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+
+          unsubscribe()
+          clearTimeout(timeout)
+
+          if (!otp) {
+            log.error('Request was not approved')
+            return reply.forbidden('Request was not approved')
+          }
+
+          log.info('Request approved, sending back OTP')
+          return reply.send(otp)
+        }
+
+        const unsubscribe = requestObj.onSnapshot(
+          (update) => {
+            const approved = update.get('approved')
+            if (approved === undefined) {
+              // update due to object creation
+              return
+            }
+            completeRequest(null, update.get('otp'))
+          },
+          (error) => {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+        )
+
+        push.send({
+          subscription: subscription.data(),
+          secretId,
+          uniqueId,
+          token
+        })
+
+        const timeout = setTimeout(completeRequest, approvalLimit)
+      })
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    url: '/api/generate/:token',
+    handler: async (request, reply) => {
+      const { firebaseAdmin, push } = server
+      const {
+        params: { token },
+        log,
+        body = { packageInfo: {} }
+      } = request
+
+      const db = firebaseAdmin.firestore()
+
+      const tokenData = await db.collection('tokens').doc(token).get()
+
+      if (!tokenData.exists) {
+        log.error('Token not found in tokens collection')
+        return reply.notFound('Token not found')
+      }
+
+      const { secretId, subscriptionId } = tokenData.data()
+
+      const subscription = await db
+        .collection('subscriptions')
+        .doc(subscriptionId)
+        .get()
+
+      if (!subscription.exists) {
+        log.error(`Subscription not found - ${subscriptionId}`)
+        return reply.notFound('Subscription not found')
+      }
+
+      const uniqueId = uniqid()
+
+      return new Promise(() => {
+        const requestObj = db.collection('requests').doc(uniqueId)
+        requestObj.set({ createdAt: new Date() })
+
+        const completeRequest = (error, otp) => {
+          requestObj.delete()
+          if (error) {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+
+          unsubscribe()
+          clearTimeout(timeout)
+
+          if (!otp) {
+            log.error('Request was not approved')
+            return reply.forbidden('Request was not approved')
+          }
+
+          log.info('Request approved, sending back OTP')
+          return reply.send(otp)
+        }
+
+        const unsubscribe = requestObj.onSnapshot(
+          (update) => {
+            const approved = update.get('approved')
+            if (approved === undefined) {
+              // update due to object creation
+              return
+            }
+            completeRequest(null, update.get('otp'))
+          },
+          (error) => {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+        )
+
+        const notification = {
+          subscription: subscription.data(),
+          secretId,
+          uniqueId,
+          token
+        }
+
+        if (body.packageInfo) {
+          notification.packageInfo = { ...body.packageInfo }
+        }
+
+        push.send(notification)
+
+        const timeout = setTimeout(completeRequest, approvalLimit)
+      })
+    },
+    schema: {
+      body: {
+        type: ['object', 'null'],
+        properties: {
+          packageInfo: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              version: { type: 'string' }
+            },
+            required: ['name', 'version'],
+            additionalProperties: false
+          }
+        },
+        additionalProperties: false
+      }
+    }
   })
 
   server.post('/api/respond', async (request, reply) => {

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -72,6 +72,7 @@ const generateOtpHandler = (server) => async (request, reply) => {
         return reply.internalServerError()
       }
     )
+    const packageInfo = body.packageInfo
 
     push.send({
       subscription: subscription.data(),
@@ -79,8 +80,8 @@ const generateOtpHandler = (server) => async (request, reply) => {
       uniqueId,
       token,
       packageInfo: {
-        ...(body.version && { version: body.version }),
-        ...(body.name && { name: body.name })
+        ...(packageInfo.version && { version: packageInfo.version }),
+        ...(packageInfo.name && { name: packageInfo.name })
       }
     })
 

--- a/server/lib/routes/otp.js
+++ b/server/lib/routes/otp.js
@@ -4,116 +4,110 @@ const uniqid = require('uniqid')
 
 const approvalLimit = 60e3
 
-const generateOtpHandler = (server) => async (request, reply) => {
-  const { firebaseAdmin, push } = server
-  const {
-    params: { token },
-    log,
-    body = { packageInfo: {} }
-  } = request
-
-  const db = firebaseAdmin.firestore()
-
-  const tokenData = await db.collection('tokens').doc(token).get()
-
-  if (!tokenData.exists) {
-    log.error('Token not found in tokens collection')
-    return reply.notFound('Token not found')
-  }
-
-  const { secretId, subscriptionId } = tokenData.data()
-
-  const subscription = await db
-    .collection('subscriptions')
-    .doc(subscriptionId)
-    .get()
-
-  if (!subscription.exists) {
-    log.error(`Subscription not found - ${subscriptionId}`)
-    return reply.notFound('Subscription not found')
-  }
-
-  const uniqueId = uniqid()
-
-  return new Promise(() => {
-    const requestObj = db.collection('requests').doc(uniqueId)
-    requestObj.set({ createdAt: new Date() })
-
-    const completeRequest = (error, otp) => {
-      requestObj.delete()
-      if (error) {
-        log.error(error.message)
-        return reply.internalServerError()
-      }
-
-      unsubscribe()
-      clearTimeout(timeout)
-
-      if (!otp) {
-        log.error('Request was not approved')
-        return reply.forbidden('Request was not approved')
-      }
-
-      log.info('Request approved, sending back OTP')
-      return reply.send(otp)
-    }
-
-    const unsubscribe = requestObj.onSnapshot(
-      (update) => {
-        const approved = update.get('approved')
-        if (approved === undefined) {
-          // update due to object creation
-          return
-        }
-        completeRequest(null, update.get('otp'))
-      },
-      (error) => {
-        log.error(error.message)
-        return reply.internalServerError()
-      }
-    )
-
-    const { name, version } = body.packageInfo
-
-    const notification = {
-      subscription: subscription.data(),
-      secretId,
-      uniqueId,
-      token
-    }
-
-    const hasPackageInfo = !!name || !!version
-
-    if (hasPackageInfo) {
-      notification.packageInfo = {
-        ...(version && { version }),
-        ...(name && { name })
-      }
-    }
-
-    push.send(notification)
-
-    const timeout = setTimeout(completeRequest, approvalLimit)
-  })
-}
-
 async function otpRoutes(server) {
-  server.route({
-    method: 'POST',
-    url: '/api/generate/:token',
-    handler: generateOtpHandler(server)
-  })
-
   /**
-   * @deprecated From now on the generate otp route will be a POST request
+   * @deprecated GET /api/generate/:token
+   *
+   * From now on the generate otp route will be a POST request
    * allowing the user to send more information about the OTP request such
    * as package name and version being deployed.
    * The GET request is here just to maintain backwards compatibility
    */
   server.route({
-    method: 'GET',
+    method: ['GET', 'POST'],
     url: '/api/generate/:token',
-    handler: generateOtpHandler(server)
+    handler: async (request, reply) => {
+      const { firebaseAdmin, push } = server
+      const {
+        params: { token },
+        log,
+        body = { packageInfo: {} }
+      } = request
+
+      const db = firebaseAdmin.firestore()
+
+      const tokenData = await db.collection('tokens').doc(token).get()
+
+      if (!tokenData.exists) {
+        log.error('Token not found in tokens collection')
+        return reply.notFound('Token not found')
+      }
+
+      const { secretId, subscriptionId } = tokenData.data()
+
+      const subscription = await db
+        .collection('subscriptions')
+        .doc(subscriptionId)
+        .get()
+
+      if (!subscription.exists) {
+        log.error(`Subscription not found - ${subscriptionId}`)
+        return reply.notFound('Subscription not found')
+      }
+
+      const uniqueId = uniqid()
+
+      return new Promise(() => {
+        const requestObj = db.collection('requests').doc(uniqueId)
+        requestObj.set({ createdAt: new Date() })
+
+        const completeRequest = (error, otp) => {
+          requestObj.delete()
+          if (error) {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+
+          unsubscribe()
+          clearTimeout(timeout)
+
+          if (!otp) {
+            log.error('Request was not approved')
+            return reply.forbidden('Request was not approved')
+          }
+
+          log.info('Request approved, sending back OTP')
+          return reply.send(otp)
+        }
+
+        const unsubscribe = requestObj.onSnapshot(
+          (update) => {
+            const approved = update.get('approved')
+            if (approved === undefined) {
+              // update due to object creation
+              return
+            }
+            completeRequest(null, update.get('otp'))
+          },
+          (error) => {
+            log.error(error.message)
+            return reply.internalServerError()
+          }
+        )
+
+        const { name, version } = body.packageInfo
+
+        const notification = {
+          subscription: subscription.data(),
+          secretId,
+          uniqueId,
+          token
+        }
+
+        const hasPackageInfo = !!name || !!version
+
+        if (hasPackageInfo) {
+          notification.packageInfo = {
+            ...(version && { version }),
+            ...(name && { name })
+          }
+        }
+
+        push.send(notification)
+
+        const timeout = setTimeout(completeRequest, approvalLimit)
+      })
+    }
   })
 
   server.post('/api/respond', async (request, reply) => {

--- a/server/test/otp.test.js
+++ b/server/test/otp.test.js
@@ -88,146 +88,155 @@ test('/otp route', async (t) => {
     clock.restore()
   })
 
-  t.test('should generate push notification on POST request with valid body', async (t) => {
-    const clock = sinon.useFakeTimers()
-    // All tokens collection
-    docStub.onFirstCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => ({
-          secretId: 'secretId',
-          subscriptionId: 'subscriptionId'
+  t.test(
+    'should generate push notification on POST request with valid body',
+    async (t) => {
+      const clock = sinon.useFakeTimers()
+      // All tokens collection
+      docStub.onFirstCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => ({
+            secretId: 'secretId',
+            subscriptionId: 'subscriptionId'
+          })
         })
       })
-    })
-    // Subscriptions collection
-    docStub.onSecondCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => sinon.stub()
+      // Subscriptions collection
+      docStub.onSecondCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => sinon.stub()
+        })
       })
-    })
-    // Requests collection
-    docStub.onThirdCall().returns({
-      set: () => {},
-      onSnapshot: () => sinon.stub(),
-      delete: () => sinon.stub()
-    })
+      // Requests collection
+      docStub.onThirdCall().returns({
+        set: () => {},
+        onSnapshot: () => sinon.stub(),
+        delete: () => sinon.stub()
+      })
 
-    let response
+      let response
 
-    server
-      .inject({
-        url: '/api/generate/55555',
-        method: 'POST',
-        body: {
-          packageInfo: {
-            version: 'v2',
-            name: '@optic/optic-expo'
+      server
+        .inject({
+          url: '/api/generate/55555',
+          method: 'POST',
+          body: {
+            packageInfo: {
+              version: 'v2',
+              name: '@optic/optic-expo'
+            }
           }
-        }
-      })
-      .then((resp) => (response = resp))
+        })
+        .then((resp) => (response = resp))
 
-    await clock.tickAsync(61e3)
+      await clock.tickAsync(61e3)
 
-    t.equal(response.statusCode, 403)
-    t.equal(docStub.calledThrice, true)
-    t.equal(sendStub.called, true)
-    clock.restore()
-  })
+      t.equal(response.statusCode, 403)
+      t.equal(docStub.calledThrice, true)
+      t.equal(sendStub.called, true)
+      clock.restore()
+    }
+  )
 
-  t.test('should generate push notification on POST request without body', async (t) => {
-    const clock = sinon.useFakeTimers()
-    // All tokens collection
-    docStub.onFirstCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => ({
-          secretId: 'secretId',
-          subscriptionId: 'subscriptionId'
+  t.test(
+    'should generate push notification on POST request without body',
+    async (t) => {
+      const clock = sinon.useFakeTimers()
+      // All tokens collection
+      docStub.onFirstCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => ({
+            secretId: 'secretId',
+            subscriptionId: 'subscriptionId'
+          })
         })
       })
-    })
-    // Subscriptions collection
-    docStub.onSecondCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => sinon.stub()
-      })
-    })
-    // Requests collection
-    docStub.onThirdCall().returns({
-      set: () => {},
-      onSnapshot: () => sinon.stub(),
-      delete: () => sinon.stub()
-    })
-
-    let response
-
-    server
-      .inject({
-        url: '/api/generate/55555',
-        method: 'POST',
-      })
-      .then((resp) => (response = resp))
-
-    await clock.tickAsync(61e3)
-
-    t.equal(response.statusCode, 403)
-    t.equal(docStub.calledThrice, true)
-    t.equal(sendStub.called, true)
-    clock.restore()
-  })
-
-  t.test('should return invalid on POST request if packageInfo is invalid', async (t) => {
-    const clock = sinon.useFakeTimers()
-    // All tokens collection
-    docStub.onFirstCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => ({
-          secretId: 'secretId',
-          subscriptionId: 'subscriptionId'
+      // Subscriptions collection
+      docStub.onSecondCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => sinon.stub()
         })
       })
-    })
-    // Subscriptions collection
-    docStub.onSecondCall().returns({
-      get: () => ({
-        exists: true,
-        data: () => sinon.stub()
+      // Requests collection
+      docStub.onThirdCall().returns({
+        set: () => {},
+        onSnapshot: () => sinon.stub(),
+        delete: () => sinon.stub()
       })
-    })
-    // Requests collection
-    docStub.onThirdCall().returns({
-      set: () => {},
-      onSnapshot: () => sinon.stub(),
-      delete: () => sinon.stub()
-    })
 
-    let response
+      let response
 
-    server
-      .inject({
-        url: '/api/generate/55555',
-        method: 'POST',
-        body: {
-          packageInfo: {
-            packageVersion: 'v2',
-            packageName: '@optic/optic-expo'
+      server
+        .inject({
+          url: '/api/generate/55555',
+          method: 'POST'
+        })
+        .then((resp) => (response = resp))
+
+      await clock.tickAsync(61e3)
+
+      t.equal(response.statusCode, 403)
+      t.equal(docStub.calledThrice, true)
+      t.equal(sendStub.called, true)
+      clock.restore()
+    }
+  )
+
+  t.test(
+    'should return invalid on POST request if packageInfo is invalid',
+    async (t) => {
+      const clock = sinon.useFakeTimers()
+      // All tokens collection
+      docStub.onFirstCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => ({
+            secretId: 'secretId',
+            subscriptionId: 'subscriptionId'
+          })
+        })
+      })
+      // Subscriptions collection
+      docStub.onSecondCall().returns({
+        get: () => ({
+          exists: true,
+          data: () => sinon.stub()
+        })
+      })
+      // Requests collection
+      docStub.onThirdCall().returns({
+        set: () => {},
+        onSnapshot: () => sinon.stub(),
+        delete: () => sinon.stub()
+      })
+
+      let response
+
+      server
+        .inject({
+          url: '/api/generate/55555',
+          method: 'POST',
+          body: {
+            packageInfo: {
+              packageVersion: 'v2',
+              packageName: '@optic/optic-expo'
+            }
           }
-        }
-      })
-      .then((resp) => (response = resp))
+        })
+        .then((resp) => (response = resp))
 
-    await clock.tickAsync(61e3)
+      await clock.tickAsync(61e3)
 
-    t.equal(response.statusCode, 400)
-    t.equal(docStub.called, false)
-    t.equal(sendStub.called, false)
-    clock.restore()
-  })
+      t.equal(response.statusCode, 400)
+      t.equal(docStub.called, false)
+      t.equal(sendStub.called, false)
+      clock.restore()
+    }
+  )
 
   t.test('should return 404 if token not found', async (t) => {
     getStub.returns({

--- a/server/test/otp.test.js
+++ b/server/test/otp.test.js
@@ -9,7 +9,6 @@ test('/otp route', async (t) => {
   const sendStub = sinon.stub()
   const getStub = sinon.stub()
   const docStub = sinon.stub()
-  const clock = sinon.useFakeTimers()
 
   const mockedFirebasePlugin = async function (server) {
     const admin = {
@@ -44,13 +43,10 @@ test('/otp route', async (t) => {
     docStub.reset()
   })
 
-  t.afterEach(() => {
-    clock.restore()
-  })
-
   t.teardown(server.close.bind(server))
 
   t.test('should generate push notification on GET request', async (t) => {
+    const clock = sinon.useFakeTimers()
     // All tokens collection
     docStub.onFirstCall().returns({
       get: () => ({
@@ -89,9 +85,11 @@ test('/otp route', async (t) => {
     t.equal(response.statusCode, 403)
     t.equal(docStub.calledThrice, true)
     t.equal(sendStub.called, true)
+    clock.restore()
   })
 
   t.test('should generate push notification on POST request', async (t) => {
+    const clock = sinon.useFakeTimers()
     // All tokens collection
     docStub.onFirstCall().returns({
       get: () => ({
@@ -123,8 +121,10 @@ test('/otp route', async (t) => {
         url: '/api/generate/55555',
         method: 'POST',
         body: {
-          version: 'v2',
-          packageName: '@optic/optic-expo'
+          packageInfo: {
+            version: 'v2',
+            packageName: '@optic/optic-expo'
+          }
         }
       })
       .then((resp) => (response = resp))
@@ -134,6 +134,7 @@ test('/otp route', async (t) => {
     t.equal(response.statusCode, 403)
     t.equal(docStub.calledThrice, true)
     t.equal(sendStub.called, true)
+    clock.restore()
   })
 
   t.test('should return 404 if token not found', async (t) => {

--- a/server/test/otp.test.js
+++ b/server/test/otp.test.js
@@ -37,16 +37,21 @@ test('/otp route', async (t) => {
     { plugin: otpRoutes }
   ])
 
+  let clock
   t.beforeEach(async () => {
     getStub.reset()
     sendStub.reset()
     docStub.reset()
+    clock = sinon.useFakeTimers()
+  })
+
+  t.afterEach(async () => {
+    clock.restore();
   })
 
   t.teardown(server.close.bind(server))
 
   t.test('should generate push notification on GET request', async (t) => {
-    const clock = sinon.useFakeTimers()
     // All tokens collection
     docStub.onFirstCall().returns({
       get: () => ({
@@ -85,13 +90,12 @@ test('/otp route', async (t) => {
     t.equal(response.statusCode, 403)
     t.equal(docStub.calledThrice, true)
     t.equal(sendStub.called, true)
-    clock.restore()
   })
+
 
   t.test(
     'should generate push notification on POST request with valid body',
     async (t) => {
-      const clock = sinon.useFakeTimers()
       // All tokens collection
       docStub.onFirstCall().returns({
         get: () => ({
@@ -136,14 +140,12 @@ test('/otp route', async (t) => {
       t.equal(response.statusCode, 403)
       t.equal(docStub.calledThrice, true)
       t.equal(sendStub.called, true)
-      clock.restore()
     }
   )
 
   t.test(
     'should generate push notification on POST request without body',
     async (t) => {
-      const clock = sinon.useFakeTimers()
       // All tokens collection
       docStub.onFirstCall().returns({
         get: () => ({
@@ -182,14 +184,12 @@ test('/otp route', async (t) => {
       t.equal(response.statusCode, 403)
       t.equal(docStub.calledThrice, true)
       t.equal(sendStub.called, true)
-      clock.restore()
     }
   )
 
   t.test(
     'should return invalid on POST request if packageInfo is invalid',
     async (t) => {
-      const clock = sinon.useFakeTimers()
       // All tokens collection
       docStub.onFirstCall().returns({
         get: () => ({
@@ -234,7 +234,6 @@ test('/otp route', async (t) => {
       t.equal(response.statusCode, 400)
       t.equal(docStub.called, false)
       t.equal(sendStub.called, false)
-      clock.restore()
     }
   )
 
@@ -260,6 +259,7 @@ test('/otp route', async (t) => {
     t.equal(sendStub.called, false)
     t.equal(data.message, 'Token not found')
   })
+
   t.test('should return 404 if subscription not found', async (t) => {
     getStub.onFirstCall().returns({
       exists: true,
@@ -302,6 +302,7 @@ test('/otp route', async (t) => {
   })
 
   t.test('should respond and update otp', async (t) => {
+    clock.restore();
     const updateStub = sinon.stub()
     updateStub.resolves()
     docStub.returns({
@@ -325,6 +326,7 @@ test('/otp route', async (t) => {
   })
 
   t.test('should return 404 if request does not exist', async (t) => {
+    clock.restore();
     // Requests collection
     docStub.returns({
       get: () => null

--- a/server/test/otp.test.js
+++ b/server/test/otp.test.js
@@ -46,7 +46,7 @@ test('/otp route', async (t) => {
   })
 
   t.afterEach(async () => {
-    clock.restore();
+    clock.restore()
   })
 
   t.teardown(server.close.bind(server))
@@ -91,7 +91,6 @@ test('/otp route', async (t) => {
     t.equal(docStub.calledThrice, true)
     t.equal(sendStub.called, true)
   })
-
 
   t.test(
     'should generate push notification on POST request with valid body',
@@ -302,7 +301,7 @@ test('/otp route', async (t) => {
   })
 
   t.test('should respond and update otp', async (t) => {
-    clock.restore();
+    clock.restore()
     const updateStub = sinon.stub()
     updateStub.resolves()
     docStub.returns({
@@ -326,7 +325,7 @@ test('/otp route', async (t) => {
   })
 
   t.test('should return 404 if request does not exist', async (t) => {
-    clock.restore();
+    clock.restore()
     // Requests collection
     docStub.returns({
       get: () => null

--- a/server/test/otp.test.js
+++ b/server/test/otp.test.js
@@ -88,7 +88,7 @@ test('/otp route', async (t) => {
     clock.restore()
   })
 
-  t.test('should generate push notification on POST request', async (t) => {
+  t.test('should generate push notification on POST request with valid body', async (t) => {
     const clock = sinon.useFakeTimers()
     // All tokens collection
     docStub.onFirstCall().returns({
@@ -123,7 +123,7 @@ test('/otp route', async (t) => {
         body: {
           packageInfo: {
             version: 'v2',
-            packageName: '@optic/optic-expo'
+            name: '@optic/optic-expo'
           }
         }
       })
@@ -134,6 +134,98 @@ test('/otp route', async (t) => {
     t.equal(response.statusCode, 403)
     t.equal(docStub.calledThrice, true)
     t.equal(sendStub.called, true)
+    clock.restore()
+  })
+
+  t.test('should generate push notification on POST request without body', async (t) => {
+    const clock = sinon.useFakeTimers()
+    // All tokens collection
+    docStub.onFirstCall().returns({
+      get: () => ({
+        exists: true,
+        data: () => ({
+          secretId: 'secretId',
+          subscriptionId: 'subscriptionId'
+        })
+      })
+    })
+    // Subscriptions collection
+    docStub.onSecondCall().returns({
+      get: () => ({
+        exists: true,
+        data: () => sinon.stub()
+      })
+    })
+    // Requests collection
+    docStub.onThirdCall().returns({
+      set: () => {},
+      onSnapshot: () => sinon.stub(),
+      delete: () => sinon.stub()
+    })
+
+    let response
+
+    server
+      .inject({
+        url: '/api/generate/55555',
+        method: 'POST',
+      })
+      .then((resp) => (response = resp))
+
+    await clock.tickAsync(61e3)
+
+    t.equal(response.statusCode, 403)
+    t.equal(docStub.calledThrice, true)
+    t.equal(sendStub.called, true)
+    clock.restore()
+  })
+
+  t.test('should return invalid on POST request if packageInfo is invalid', async (t) => {
+    const clock = sinon.useFakeTimers()
+    // All tokens collection
+    docStub.onFirstCall().returns({
+      get: () => ({
+        exists: true,
+        data: () => ({
+          secretId: 'secretId',
+          subscriptionId: 'subscriptionId'
+        })
+      })
+    })
+    // Subscriptions collection
+    docStub.onSecondCall().returns({
+      get: () => ({
+        exists: true,
+        data: () => sinon.stub()
+      })
+    })
+    // Requests collection
+    docStub.onThirdCall().returns({
+      set: () => {},
+      onSnapshot: () => sinon.stub(),
+      delete: () => sinon.stub()
+    })
+
+    let response
+
+    server
+      .inject({
+        url: '/api/generate/55555',
+        method: 'POST',
+        body: {
+          packageInfo: {
+            packageVersion: 'v2',
+            packageName: '@optic/optic-expo'
+          }
+        }
+      })
+      .then((resp) => (response = resp))
+
+    await clock.tickAsync(61e3)
+
+    t.equal(response.statusCode, 400)
+    t.equal(docStub.called, false)
+    t.equal(sendStub.called, false)
     clock.restore()
   })
 


### PR DESCRIPTION
This PR allows the client to send some package info when requesting an OTP. 

This is a breaking change since the OTP request is now a POST instead of a GET and receives the package info as the body of the request as follows:

This change is backwards compatible with old versions of both the action and the app (the server still accepts a get request without any package info and the app will be kept the same if the package info field is not populated.

```json
{
	"packageInfo": {
		"name": "package-name",
		"version": "v5.1.4"
	}
}
```

This information will then be seen in the Optic app when the user is approving the request.
<img src="https://github.com/nearform/optic/assets/6863574/a5bf05c3-21ab-4de0-a4f0-bb89ad037b23" width="300px">


Resolves nearform/optic-expo#1186.