### PR TITLE
chore: increase push notification priority

### DIFF
--- a/server/lib/plugins/push.js
+++ b/server/lib/plugins/push.js
@@ -18,6 +18,7 @@ async function sendExpoPush(
       {
         to: subscription.token,
         sound: 'default',
+        priority: 'high',
         body: 'One Time Password requested',
         data: { uniqueId, token, secretId, packageInfo }
       }


### PR DESCRIPTION
This increases the priority of the push notifications sent to the optic expo app to the maximum allowed, making the notification wake up locked devices and increasing the chance for a notification to be seen.

closes: https://github.com/nearform/optic-expo/issues/1153